### PR TITLE
게시글 목록 페이징 ui 추가 

### DIFF
--- a/self_django/board/templates/board/post_list.html
+++ b/self_django/board/templates/board/post_list.html
@@ -9,7 +9,7 @@
 
 <!-- 게시글 리스트 출력 -->
 <ul>
-  {% for post in posts %}
+  {% for post in page_obj %}
     <li>
       <!-- 제목: 상세 페이지로 이동 -->
       <a href="{% url 'post_detail' post.pk %}">{{ post.title }}</a>
@@ -36,13 +36,23 @@
 
 
 <div>
-    {% if page_obj.has_previoud %}
-        <a href="?page={{ page_obj.has_previous_page_number }}">이전</a>
+    {% if page_obj.has_previous %}
+        <a href="?page={{ page_obj.previous_page_number }}">이전</a>
     {% endif %}
 
     <span>현재 페이지: {{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span>
 
     {% if page_obj.has_next %}
-        <a href="?page{{ page_obj.has_next_page_number }}">다음</a>
+        <a href="?page={{ page_obj.next_page_number }}">다음</a>
     {% endif %}
+</div>
+
+<div>
+    {% for num in page_obj.paginator.page_range %}
+        {% if num == page_obj.number %}
+            <strong>{{ num }}</strong>
+        {% else %}
+            <a href="?page={{ num }}">{{ num }}</a>
+        {% endif %}
+    {% endfor %}
 </div>

--- a/self_django/board/templates/board/post_list.html
+++ b/self_django/board/templates/board/post_list.html
@@ -33,3 +33,16 @@
     <li>작성된 게시글이 없습니다.</li>
   {% endfor %}
 </ul>
+
+
+<div>
+    {% if page_obj.has_previoud %}
+        <a href="?page={{ page_obj.has_previous_page_number }}">이전</a>
+    {% endif %}
+
+    <span>현재 페이지: {{ page_obj.number }} / {{ page_obj.paginator.num_pages }}</span>
+
+    {% if page_obj.has_next %}
+        <a href="?page{{ page_obj.has_next_page_number }}">다음</a>
+    {% endif %}
+</div>

--- a/self_django/board/views.py
+++ b/self_django/board/views.py
@@ -1,11 +1,16 @@
 from django.shortcuts import render, get_object_or_404, redirect
 from .models import Post
 from .forms import PostForm
-
+from django.core.paginator import Paginator
 
 def post_list(request): # read
-    posts = Post.objects.all().order_by('-created_at')
-    return render(request, 'board/post_list.html', {'posts' : posts})
+    post_list = Post.objects.all().order_by('-created_at')
+    paginator = Paginator(post_list, 5) 
+
+    page_number = request.GET.get('page')
+    page_obj = paginator.get_page(page_number)
+
+    return render(request, 'board/post_list.html', {'page_obj' : page_obj})
 
 def post_detail(request, pk): # deep read zz
     post = get_object_or_404(Post, pk = pk)
@@ -41,3 +46,6 @@ def post_delete(request, pk):
         return redirect('post_list') 
 
     return redirect('post_detail', pk=pk)
+
+
+


### PR DESCRIPTION
## 작업 개요
-게시글 목록 하단에 페이지 번호 ui 추가

## 작업 내용
-'page_obj.paginator.page_range'를 활용하여 페이지 번호 표시
-'이전/다음' 추가 

## 테스트
-로컬 서버에서 정상적으로 작동하는지 확인(페이지 번호, 이전/다음)

## 기타
-기존에 'posts'를 순회하던 부분을 'page_obj'로 변경 
